### PR TITLE
Enhance chat editing cleanup to close editors on session disposal

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditingService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditingService.ts
@@ -86,7 +86,8 @@ export class ChatEditingService extends Disposable implements IChatEditingServic
 			return decidedEntries.map(entry => entry.entryId);
 		}));
 		this._chatService.onDidDisposeSession((e) => {
-			if (e.reason === 'cleared' && this._currentSessionObs.get()?.chatSessionId === e.sessionId) {
+			const currentSession = this._currentSessionObs.get();
+			if (currentSession?.chatSessionId === e.sessionId) {
 				this.killCurrentEditingSession();
 			}
 		});
@@ -179,6 +180,12 @@ export class ChatEditingService extends Disposable implements IChatEditingServic
 	killCurrentEditingSession() {
 		const currentSession = this._currentSessionObs.get();
 		if (currentSession) {
+			// Close all editors associated with this session
+			const groupedEditors = this._findGroupedEditors();
+			for (const [group, editor] of groupedEditors) {
+				group.closeEditor(editor, { preserveFocus: true });
+			}
+			
 			this._onDidDisposeEditingSession.fire(currentSession);
 			currentSession.dispose();
 			this._currentSessionObs.set(null, undefined);


### PR DESCRIPTION
- Handle both 'cleared' and 'initializationFailed' disposal reasons
- Close associated editors when killing editing session

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
